### PR TITLE
use fqdn var instead of item from inventory

### DIFF
--- a/tasks/default.yml
+++ b/tasks/default.yml
@@ -10,7 +10,7 @@
 # Will include all hosts the playbook is run on.
 # Credits to rothgar: https://gist.github.com/rothgar/8793800
 - name: Build hosts file (backups will be made)
-  lineinfile: dest=/etc/hosts line='{{ hostvars[item].ansible_default_ipv4.address }} {{ hostvars[item].ansible_hostname }}  {{ item }}' state=present backup=yes
+  lineinfile: dest=/etc/hosts line='{{ hostvars[item].ansible_default_ipv4.address }} {{ hostvars[item].ansible_hostname }}  {{ fqdn }}' state=present backup=yes
   when: hostvars[item].ansible_default_ipv4.address is defined
   with_items: groups['all']
 


### PR DESCRIPTION
Hi,

I had added IP addresses in my inventory file and my use-case of this module is that IP address is provided using a variable from outside. In my case where my inventory file had ip addresses, the host alias in /etc/hosts file was getting set to the IP address picked up from the inventory file instead of the fqdn variable itself.

This PR fixes that.

