### PR TITLE
Fix /etc/hosts auto-populate task

### DIFF
--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -6,13 +6,9 @@
   action: setup
   when: ansible_hostname != fqdn
 
-# Idempotent way to build a /etc/hosts file with Ansible using your Ansible hosts inventory for a source.
-# Will include all hosts the playbook is run on.
-# Credits to rothgar: https://gist.github.com/rothgar/8793800
 - name: Build hosts file (backups will be made)
-  lineinfile: dest=/etc/hosts line='{{ hostvars[item].ansible_default_ipv4.address }} {{ fqdn }} {{ hostvars[item].ansible_hostname }}' state=present backup=yes
-  when: hostvars[item].ansible_default_ipv4.address is defined
-  with_items: groups['all']
+  lineinfile: dest=/etc/hosts line='{{ ansible_default_ipv4.address }} {{ fqdn }} {{ inventory_hostname_short }}' state=present backup=yes
+  when: ansible_default_ipv4.address is defined
 
 - name: restart hostname
   service: name=hostname state=restarted


### PR DESCRIPTION
The way it worked before was fundamentally broken. As soon as an
inventory would contain more than one host, we would bind ip addresses
to the wrong fqdn.

With this commit, we lose the ability to populate our host with our
whole inventory, but at least it's not broken.

fixes #10