### PR TITLE
Fix role failed on ansible_distribution == OracleLinux 

### DIFF
--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -14,4 +14,4 @@
   service: name=hostname state=restarted
   async: 45
   poll: 0
-  when: ansible_distribution not in [ 'RedHat', 'CentOS' ]
+  when: ansible_distribution not in [ 'RedHat', 'CentOS', 'OracleLinux' ]


### PR DESCRIPTION
OracleLinux are same as RedHat or CentOS
It's fixing this issue :  
FAILED! => {"changed": false, "failed": true, "msg": "Could not find the requested service \"'hostname'\": "}

Eventually, we can also change 
when: ansible_distribution not in [ 'RedHat', 'CentOS', 'OracleLinux' ]
with
when: ansible_os_family not 'RedHat'
but i can't test on all OS type and it's can introduce bad side effect ?