### PR TITLE
Fix #37 : Update redhat : install libselinux-python

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,3 +1,7 @@
 ---
+- name: Redhat | Install libselinux-python
+  yum:
+    name: libselinux-python
+
 - name: Redhat | Update sysconfig
   lineinfile: dest=/etc/sysconfig/network line="HOSTNAME={{ fqdn }}" regexp="HOSTNAME="


### PR DESCRIPTION
Update redhat : install libselinux-python
otherwise on fresh install of Centos6 :
Aborting, target uses selinux but python bindings (libselinux-python) aren't installed!"