### PR TITLE
RHEL8/CentOS8 have a different package name

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,7 +1,7 @@
 ---
-- name: Redhat | Install libselinux-python
+- name: Redhat | Install Python libselinux package
   yum:
-    name: libselinux-python
+    name: "{{ ( (ansible_facts.distribution_major_version | int) < 8) | ternary('libselinux-python','python3-libselinux') }}"
 
 - name: Redhat | Update sysconfig
   lineinfile: dest=/etc/sysconfig/network line="HOSTNAME={{ fqdn }}" regexp="HOSTNAME="


### PR DESCRIPTION
This resolution was copied from the Kubespray pull request merged in August 2019.

https://github.com/kubernetes-sigs/kubespray/pull/5127/commits/c4c7e7b4a0286d5ba9351c9ff26266e6b3bebab4