### PR TITLE
Switch from "include:" to "import_tasks:" to resolve warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Sets Fully qualified domain name (FQDN)
 Requirements
 ------------
 
-Ansible version 2.0+
+Ansible version 2.4+
 
 ## Platforms
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,15 +26,15 @@ boxes = [
     :ram => "256"
   },
   {
-    :name => "debian-711",
-    :box => "bento/debian-7.11",
+    :name => "debian-12",
+    :box => "debian/bookworm64",
     :ip => '10.0.0.14',
     :cpu => "50",
     :ram => "256"
   },
   {
-    :name => "debian-86",
-    :box => "bento/debian-8.6",
+    :name => "debian-11",
+    :box => "debian/bullseye64",
     :ip => '10.0.0.15',
     :cpu => "50",
     :ram => "256"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
     author: Roman Gorodeckij
     description: Set FQDN and hostname
     license: MIT
-    min_ansible_version: 2.0
+    min_ansible_version: 2.4
     platforms:
         - name: EL
           versions:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,7 @@
 ---
 galaxy_info:
+    role_name: fqdn
+    namespace: holms
     author: Roman Gorodeckij
     description: Set FQDN and hostname
     license: MIT
@@ -20,6 +22,4 @@ galaxy_info:
     categories:
         - networking
         - system
-
-dependencies: []
-
+    dependencies: {}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,16 +1,16 @@
 ---
 - name: fqdn | Configure Debian
-  include: debian.yml
+  import_tasks: debian.yml
   when: ansible_os_family == 'Debian'
 
 - name: fqdn | Configure Redhat
-  include: redhat.yml
+  import_tasks: redhat.yml
   when: ansible_os_family == 'RedHat'
 
 - name: fqdn | Configure Linux
-  include: linux.yml
+  import_tasks: linux.yml
   when: ansible_system in  [ 'Linux' ]
 
 - name: fqdn | Configure Windows
-  include: windows.yml
+  import_tasks: windows.yml
   when: ansible_system in  [ 'Win32NT' ]

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -4,11 +4,11 @@
   connection: local
   become: true
   pre_tasks:
-    - include: pre.yml
+    - import_tasks: pre.yml
   roles:
     - ../../
   post_tasks:
-    - include: post.yml
+    - import_tasks: post.yml
   vars:
     hostname: mx
     fqdn: mx.example.com

--- a/tests/vagrant.yml
+++ b/tests/vagrant.yml
@@ -4,11 +4,11 @@
   remote_user: vagrant
   become: true
   pre_tasks:
-    - include: pre.yml
+    - import_tasks: pre.yml
   roles:
     - ../../
   post_tasks:
-    - include: post.yml
+    - import_tasks: post.yml
   vars:
     hostname: mx
     fqdn: mx.example.com


### PR DESCRIPTION
As of Ansible 2.4, "include:" is deprecated in favor of
"include_tasks:" and "import_tasks:". This change removes the
DEPRECATION WARNING that recent Ansible versions output as a result.

As a side-effect, this role no longer works with Ansible versions
older than 2.4, but older versions of this role (such as v1.2) are
still available.

This PR also has a couple of janitorial fixes.

Closes #45 
